### PR TITLE
Correct terms, unify terms in the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@ Salary slip kata
 ================
 ## Problem description: Salary slip generator for UK companies.
 
-  A typical salary slip contains employee details like employee id, employee name and their salary details like their gross salary, national insurance contributions, tax-free allowance, taxable income and taxes payable.
+  A typical salary slip contains employee details like employee id, employee name and their monthly salary details like their gross salary, national insurance contributions, tax-free allowance, taxable income and tax payable.
 
   Salary slips are generated each month for every employee.
 
 
 ### Acceptance criteria:
-- Salary slip generator should pass an employee with its Employee Id, Employee Name and Annual Salary
+- Salary slip generator should pass an employee with its Employee Id, Employee Name and Annual Gross Salary
 - Salary slip should contain the Employee ID, Employee Name, Gross Salary, National Insurance contributions, Tax-free allowance, Taxable income and Tax payable for the month
 - The entry point should be the following interface, which you can not change:
   ```java
@@ -27,12 +27,12 @@ Each iteration adds more rules to the calculation. Some iterations also introduc
 
 In a given iteration, all the salary slips contain the same number fields for each employee (if a tax or contribution does not apply for a given employee, just put £0.00).
 
-This means that for each iteration you will need to add fields to the `SalarySlip` class. In the first iteration, `SalarySlip` only contains the Employee ID, Employee Name and Gross Salary.
+This means that for each iteration you will need to add fields to the `SalarySlip` class. In the first iteration, `SalarySlip` only contains the Employee ID, Employee Name and Monthly Gross Salary.
 
 #### Iteration 1: for an annual salary of £5,000.00
 This is the most basic case.
 
-  <p>*Given* I have an employee John J Doe with an annual salary of £5,000.00</p>
+  <p>*Given* I have an employee John J Doe with an annual gross salary of £5,000.00</p>
   <p>*When* I generate a monthly salary slip for the employee</p>
   <p>*Then* the monthly salary slip should contain the below:</p>
 
@@ -41,9 +41,9 @@ This is the most basic case.
            Gross Salary: £416.67
 
 Calculation rules:
- * Gross salary: The gross salary is the employee's annual gross salary divided by 12
+ * Monthly Gross Salary: The monthly gross salary is the employee's annual gross salary divided by 12
 
-#### Iteration 2: for an annual salary of £9,060.00
+#### Iteration 2: for an annual gross salary of £9,060.00
 
 Here we introduce the National Insurance contribution
 
@@ -57,7 +57,7 @@ Here we introduce the National Insurance contribution
 Calculation rules:
  * National Insurance contributions: Any amount of money earned above a gross annual salary of £8,060.00 is subject to a National Insurance contribution of 12%
 
-#### Iteration 3: for an annual salary of £12,000.00
+#### Iteration 3: for an annual gross salary of £12,000.00
 
 This employee also needs to pay taxes
 
@@ -74,7 +74,7 @@ This employee also needs to pay taxes
 Calculation rules:
  * Taxable income: Any amount of money earned above a gross annual salary of £11,000.00 is taxed at 20%
 
-#### Iteration 4: for an annual salary of £45,000.00
+#### Iteration 4: for an annual gross salary of £45,000.00
 
 This employee pays a higher band of National Insurance and Income Tax.
 
@@ -92,7 +92,7 @@ Calculation rules:
  * Taxable income (higher rate): Any amount of money earned above a gross annual salary of £43,000.00 is taxed at 40%
  * National Insurance (higher contributions): Any amount of money earned above a gross annual salary of £43,000.00 is only subject to a 2% NI contribution
 
-#### Iteration 5: for annual salaries of £101,000.00; £111,000.00; £122,000.00 and £150,000.00
+#### Iteration 5: for annual gross salaries of £101,000.00; £111,000.00; £122,000.00 and £150,000.00
 
 For high earners, the tax-free allowance decreases.
 
@@ -134,9 +134,9 @@ For high earners, the tax-free allowance decreases.
            Tax Payable: £4,466.67
 
 Calculation rules:
- * Tax-free allowance: When the Gross Salary exceeds £100,000.00, the tax-free allowance starts decreasing. It decreases by £1 for every £2 earned over £100,000.00. And this excess is taxed at the Higher rate tax.
+ * Tax-free allowance: When the Annual Gross Salary exceeds £100,000.00, the tax-free allowance starts decreasing. It decreases by £1 for every £2 earned over £100,000.00. And this excess is taxed at the Higher rate tax.
 
-#### Iteration 9: for an annual salary of £160,000.00
+#### Iteration 9: for an annual gross salary of £160,000.00
 
 The employee goes into the additional rate band.
 


### PR DESCRIPTION
Make all terms related to salary, gross salary, annual gross salary, consistent and uniform to avoid ambiguity.

Also added a note to relax the usage of labels or formatting to represent the salary slip.
